### PR TITLE
ci: update deploy action : set-env is deprecated

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v2
 
       - shell: bash
-        run: echo '::set-env name=TEMPLATE_APP_HEAD_REF::${{ github.head_ref }}'
-      
+        run: echo 'TEMPLATE_APP_HEAD_REF=${{ github.head_ref }}' >> $GITHUB_ENV
+
       - shell: bash
-        run: echo '::set-env name=TEMPLATE_APP_REF::${{ github.ref }}'
+        run: echo 'TEMPLATE_APP_REF=${{ github.ref }}' >> $GITHUB_ENV
 
       - name: Check output
         run: echo ${TEMPLATE_APP_REF:-${TEMPLATE_APP_REF##*/}}


### PR DESCRIPTION
Update deploy action, due to deprecated set-env command: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/