### PR TITLE
feat: ES index

### DIFF
--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,16 +1,12 @@
 {
   "root": true,
-  "extends": [
-    "eslint:recommended",
-    "plugin:node/recommended",
-    "plugin:prettier/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:node/recommended", "plugin:prettier/recommended"],
   "env": {
     "node": true,
     "es6": true,
     "mocha": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   }
 }

--- a/server/src/common/esClient/mongoosastic/index.js
+++ b/server/src/common/esClient/mongoosastic/index.js
@@ -8,6 +8,7 @@
 /* eslint-disable no-plusplus */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-param-reassign */
+
 "use strict";
 
 const serialize = require("./serialize");


### PR DESCRIPTION
- add ASCII folding
- missing types by default
- sub-documents indexation
- bump eslint ecma version to 2020

### IMPORTANT
Les champs de type tableau sont "Nested" par défaut si aucun type n'est spécifié.

exemple de tableau de string :

```
  romes: {
    type: [String],
    default: [],
    description: "Liste des romes lié au métier",
  },
```